### PR TITLE
Issue #18: `dotnet new` wizard could consider initial selection

### DIFF
--- a/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewWizard.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewWizard.java
@@ -13,14 +13,21 @@ package org.eclipse.acute.dotnetnew;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -29,6 +36,7 @@ import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
@@ -38,6 +46,33 @@ public class DotnetNewWizard extends Wizard implements INewWizard {
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		wizardPage = new DotnetNewWizardPage();
+
+		Iterator<Object> selectionIterator = selection.iterator();
+		Set<IWorkingSet> workingSets = new HashSet<>();
+		IResource selectedResource = null;
+
+		while (selectionIterator.hasNext()) {
+			Object element = selectionIterator.next();
+			IResource asResource = toResource(element);
+
+			if (asResource != null && selectedResource == null) {
+				selectedResource = asResource;
+			} else {
+				IWorkingSet asWorkingSet = Adapters.adapt(element, IWorkingSet.class);
+				if (asWorkingSet != null) {
+					workingSets.add(asWorkingSet);
+				}
+			}
+		}
+
+		if (workingSets.isEmpty() && selectedResource != null) {
+			workingSets.addAll(getWorkingSets(selectedResource));
+		}
+		wizardPage.setWorkingSets(workingSets);
+
+		if (selectedResource != null) {
+			wizardPage.setDirectory(toFile(selectedResource));
+		}
 	}
 
 	@Override
@@ -48,7 +83,7 @@ public class DotnetNewWizard extends Wizard implements INewWizard {
 	@Override
 	public boolean performFinish() {
 		String template = wizardPage.getTemplate();
-		File location = wizardPage.getLocation();
+		File location = wizardPage.getDirectory();
 		String projectName = wizardPage.getProjectName();
 
 		if (!location.exists()) {
@@ -101,10 +136,42 @@ public class DotnetNewWizard extends Wizard implements INewWizard {
 				}
 			}
 		} catch (CoreException e) {
-			MessageDialog.openError(getShell(), "Unable to load project description", "");
+			MessageDialog.openError(getShell(), "Error", "Unable to load project description.");
 			return false;
 		}
 		return true;
+	}
+
+	private Set<IWorkingSet> getWorkingSets(IResource resource) {
+		IWorkingSet[] allWorkingSets = PlatformUI.getWorkbench().getWorkingSetManager().getAllWorkingSets();
+		Set<IWorkingSet> fileWorkingSets = new HashSet<>();
+
+		for (IWorkingSet iWorkingSet : allWorkingSets) {
+			IAdaptable[] elements = iWorkingSet.getElements();
+			if (Arrays.asList(elements).contains(resource.getProject())) {
+				fileWorkingSets.add(iWorkingSet);
+			}
+		}
+
+		return fileWorkingSets;
+	}
+
+	private IResource toResource(Object o) {
+		if (o instanceof IResource) {
+			return (IResource) o;
+		} else if(o instanceof IAdaptable) {
+			return ((IAdaptable) o).getAdapter(IResource.class);
+		}else {
+			return null;
+		}
+	}
+
+	private File toFile(IResource r) {
+		IPath location = r.getLocation();
+		if (location.toFile().isFile()) {
+			return location.toFile().getParentFile().getAbsoluteFile();
+		}
+		return location == null ? null : location.toFile();
 	}
 
 }

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewWizardPage.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewWizardPage.java
@@ -70,7 +70,11 @@ public class DotnetNewWizardPage extends WizardPage {
 		setDescription("Create a new Dotnet project, using the `dotnet new` command");
 	}
 
-	public File getLocation() {
+	public void setDirectory(File directory) {
+		this.directory = directory;
+	}
+
+	public File getDirectory() {
 		if (isDirectoryAndProjectLinked) {
 			return directory;
 		} else {
@@ -92,6 +96,10 @@ public class DotnetNewWizardPage extends WizardPage {
 
 	public IWorkingSet[] getWorkingSets() {
 		return workingSetsGroup.getSelectedWorkingSets();
+	}
+
+	public void setWorkingSets(Set<IWorkingSet> workingSets) {
+		this.workingSets = workingSets;
 	}
 
 	@Override
@@ -223,6 +231,10 @@ public class DotnetNewWizardPage extends WizardPage {
 			wsSel = new StructuredSelection(this.workingSets.toArray());
 		}
 		this.workingSetsGroup = new WorkingSetGroup(workingSetComposite, wsSel, workingSetIds);
+
+		if (directory != null) {
+			updateDirectory(directory.getAbsolutePath());
+		}
 	}
 
 	private void updateProjectName() {


### PR DESCRIPTION
Now retrieves the current highlighted item and uses it to pre-populate the location field for when 'right-click > New' is used