### PR TITLE
Issue #45 Add `Run As > .NET Core Test` that maps to dotnet test

### DIFF
--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/AllTestTests.java
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/AllTestTests.java
@@ -8,23 +8,18 @@
  * Contributors:
  *  Lucas Bullen (Red Hat Inc.) - Initial implementation
  *******************************************************************************/
-package org.eclipse.acute.SWTBotTests;
+
+package org.eclipse.acute.SWTBotTests.dotnettest;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.eclipse.acute.SWTBotTests.dotnetnew.AllNewTests;
-import org.eclipse.acute.SWTBotTests.dotnetrun.AllRunTests;
-import org.eclipse.acute.SWTBotTests.dotnettest.AllTestTests;
-import org.eclipse.acute.SWTBotTests.dotnetexport.AllExportTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	AllNewTests.class,
-	AllRunTests.class,
-	AllExportTests.class,
-	AllExportTests.class
+	TestConfiguration.class,
+	TestRun.class
 })
-public class AllTests {
+public class AllTestTests {
 
 }

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project.Tests.json
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project.Tests.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable"
+  },
+  
+  "dependencies": {
+  	"Microsoft.NET.Test.Sdk":"15.0.0" ,
+  	"xunit":"2.2.0",
+  	"xunit.runner.visualstudio":"2.2.0"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project1.Tests.csproj
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project1.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+  
+</Project>

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project2.Tests.csproj
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/Project2.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+  
+</Project>

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/ProjectTestsFail.cs
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/ProjectTestsFail.cs
@@ -1,0 +1,18 @@
+using System;
+using Xunit;
+
+namespace Tests
+{
+    public class ProjectTestsFail
+    {   
+        [Theory] 
+        [InlineData(3)] 
+        [InlineData(4)] 
+        [InlineData(5)] 
+        [InlineData(6)]
+        public void ReturnTrueGivenLessThan5(int value) 
+        { 
+      		Assert.True(value<5, $"{value} should be less than 5"); 
+        }
+    }
+}

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/ProjectTestsPass.cs
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/ProjectTestsPass.cs
@@ -1,0 +1,16 @@
+using System;
+using Xunit;
+namespace Tests
+{
+    public class ProjectTestsPass
+    {   
+        [Theory] 
+        [InlineData(1)] 
+        [InlineData(2)] 
+        [InlineData(3)]
+        public void ReturnTrueGivenLessThan4(int value) 
+        { 
+      		Assert.True(value < 4, $"{value} should be less than 4"); 
+        }
+    }
+}

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/TestConfiguration.java
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/TestConfiguration.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+
+package org.eclipse.acute.SWTBotTests.dotnettest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.acute.SWTBotTests.AbstractDotnetTest;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.swtbot.swt.finder.waits.Conditions;
+import org.junit.Test;
+
+public class TestConfiguration extends AbstractDotnetTest {
+	private String name = "Test_config1";
+	
+	@Override
+	public void setup() throws CoreException {
+		super.buildEmptyProject();
+		
+		String projectFileName;
+		if(dotnetVersion.matches("2\\.0.*")) {
+			projectFileName = "Project2.Tests.csproj";
+		}else if(dotnetVersion.matches("1\\.0\\.1.*")){
+			projectFileName = "Project1.Tests.csproj";
+		}else {
+			projectFileName = "Project.Tests.json";
+		}
+		csprojFile = this.project.getFile(projectFileName);
+		csprojFile.create(getClass().getResourceAsStream(csprojFile.getName()), true, new NullProgressMonitor());
+		
+		csharpSourceFile = this.project.getFile("ProjectTestsPass.cs");
+		csharpSourceFile.create(getClass().getResourceAsStream(csharpSourceFile.getName()), true, new NullProgressMonitor());
+
+		bot.menu("Run").menu("Run Configurations...").click();
+		
+		bot.shell("Run Configurations").activate();
+		bot.tree().select(".NET Core Test");
+		bot.toolbarButtonWithTooltip("New launch configuration").click();
+		bot.textWithLabel("Project:").setText(ResourcesPlugin.getWorkspace().getRoot().getLocation().toString()+csprojFile.getFullPath().toPortableString());
+		bot.textWithLabel("Name:").setText(name);
+	}
+	
+	@Test
+	public void testSelectTestMethod() {
+		bot.radio("Run a single test").click();
+		bot.button("Search", 0).click();
+		bot.waitUntil(Conditions.shellIsActive("Class Selection"), 30000);
+		bot.button("OK").click();
+
+		String className = bot.textWithLabel("Test class:").getText();
+
+		bot.button("Search", 1).click();
+		bot.waitUntil(Conditions.shellIsActive("Method Selection from \""+className+"\""));
+		assertTrue("No methods found for selected class", bot.button("OK").isEnabled());
+		bot.button("OK").click();
+
+		bot.button("Apply").click();
+		bot.button("Close").click();
+	}
+
+	@Override
+	public void tearDown() throws CoreException {
+		bot.menu("Run").menu("Run Configurations...").click();
+		
+		bot.shell("Run Configurations").activate();
+		bot.tree().expandNode(".NET Core Test").select(name);
+		
+		bot.toolbarButtonWithTooltip("Delete selected launch configuration(s)").click();
+		bot.shell("Confirm Launch Configuration Deletion").activate();
+		bot.button("Yes").click();
+		
+		bot.shell("Run Configurations").activate();
+		bot.button("Close").click();
+		
+		super.tearDown();
+	}
+}

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/TestRun.java
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnettest/TestRun.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+
+package org.eclipse.acute.SWTBotTests.dotnettest;
+
+import java.util.List;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.acute.SWTBotTests.AbstractDotnetTest;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.finders.ChildrenControlFinder;
+import org.eclipse.swtbot.swt.finder.matchers.WidgetOfType;
+import org.eclipse.swtbot.swt.finder.waits.ICondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.junit.Test;
+
+public class TestRun extends AbstractDotnetTest{
+	
+	@Override
+	public void setup() throws CoreException {
+		super.buildEmptyProject();
+		
+		String projectFileName;
+		if(dotnetVersion.matches("2\\.0.*")) {
+			projectFileName = "Project2.Tests.csproj";
+		}else if(dotnetVersion.matches("1\\.0\\.1.*")){
+			projectFileName = "Project1.Tests.csproj";
+		}else {
+			projectFileName = "Project.Tests.json";
+		}
+		csprojFile = this.project.getFile(projectFileName);
+		csprojFile.create(getClass().getResourceAsStream(csprojFile.getName()), true, new NullProgressMonitor());
+	}
+
+	@Test
+	public void testDotnetRunSuccessful() throws CoreException {
+		int exitCode = runTest("ProjectTestsPass.cs");
+		assertTrue("Test's exit code was incorrect; expected: 0, actual: "+exitCode, exitCode == 0);
+	}
+	
+	@Test
+	public void testDotnetRunFailure() throws CoreException {
+		int exitCode = runTest("ProjectTestsFail.cs");
+		assertTrue("Test's exit code was incorrect; expected: 1, actual: "+exitCode, exitCode == 1);
+	}
+	
+	private int runTest(String csharpSourceFileName) throws CoreException {
+		csharpSourceFile = this.project.getFile(csharpSourceFileName);
+		csharpSourceFile.create(getClass().getResourceAsStream(csharpSourceFile.getName()), true, new NullProgressMonitor());
+
+		SWTBotView view = bot.viewByTitle("Project Explorer");
+		List<Tree> explorerControls = new ChildrenControlFinder(
+				view.getWidget()).findControls(WidgetOfType.widgetOfType(Tree.class));
+		SWTBotTree explorerTree = new SWTBotTree((Tree) explorerControls.get(0));
+		SWTBotTreeItem projectItem = explorerTree.getTreeItem(project.getName());
+		SWTBotTreeItem fileItem = projectItem.expand().getNode(csharpSourceFile.getName());
+		fileItem.select().contextMenu("Open").click();
+		SWTBotEditor editor = bot.editorByTitle(csharpSourceFile.getName());
+		editor.setFocus();
+	
+		bot.styledText(1).contextMenu("Run As").menu("2 .NET Core Test").click();		
+		SWTBotView debugView = bot.viewByTitle("Debug");
+		List<Tree> debugControls = new ChildrenControlFinder(
+				debugView.getWidget()).findControls(WidgetOfType.widgetOfType(Tree.class));
+		SWTBotTree debugTree = new SWTBotTree((Tree) debugControls.get(0));
+		
+		bot.waitUntil(new ICondition() {
+			@Override
+			public boolean test() throws Exception {
+				for(SWTBotTreeItem item : debugTree.getAllItems()) {
+					for (String node : item.expand().getNodes()) {
+						if(node.matches("<terminated, exit value: \\d>.NET Core Tests")) {
+							return true;
+						}
+					}
+				}
+				return false;
+			}
+			@Override public void init(SWTBot bot) {
+				debugView.setFocus();
+			}
+			@Override
+			public String getFailureMessage() {
+				SWTBotView consoleView = bot.viewByPartName("Console");
+				return "Test program failed: "+ consoleView.bot().styledText().getText();
+			}
+		},30000);
+		
+		for(SWTBotTreeItem item : debugTree.getAllItems()) {
+			for (String node : item.expand().getNodes()) {
+				if(node.matches("<terminated, exit value: \\d>.NET Core Tests")) {
+					return Integer.parseInt(node.replace("<terminated, exit value: ", "").replace(">.NET Core Tests", ""));
+				}
+			}
+		}
+		return -1;
+	}
+}

--- a/org.eclipse.acute/plugin.xml
+++ b/org.eclipse.acute/plugin.xml
@@ -131,4 +131,50 @@
                <selection class="org.eclipse.core.resources.IResource"/>
       </wizard>
    </extension>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+           name=".NET Core Test"
+           delegate="org.eclipse.acute.dotnettest.DotnetTestDelegate"
+           modes="run"
+           id="org.eclipse.acute.dotnettest.DotnetTestDelegate">
+        </launchConfigurationType>
+   </extension>
+   <extension
+       point="org.eclipse.debug.ui.launchConfigurationTabGroups">
+       <launchConfigurationTabGroup
+           class="org.eclipse.acute.dotnettest.DotnetTestTabGroup"
+           id="org.eclipse.acute.dotnettest.DotnetTestTabGroup"
+           type="org.eclipse.acute.dotnettest.DotnetTestDelegate">
+       </launchConfigurationTabGroup>
+   </extension>
+    <extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
+         <launchConfigurationTypeImage
+            id="org.eclipse.acute.dotnettest.DotnetTestTypeImage"
+            configTypeID="org.eclipse.acute.dotnettest.DotnetTestDelegate"
+            icon="icons/dotnet.png">
+         </launchConfigurationTypeImage>
+    </extension>
+    <extension point="org.eclipse.debug.ui.launchShortcuts">
+       <shortcut
+           id="org.eclipse.acute.dotnettest.Shortcut"
+           class="org.eclipse.acute.dotnettest.DotnetTestDelegate"
+           label=".NET Core Test"
+           icon="icons/dotnet.png"
+           modes="run">
+         <contextualLaunch>
+            <enablement>
+               <with variable="selection">
+                  <count value="1"/>
+                  <iterate>
+                     <adapt type="org.eclipse.core.resources.IResource">
+                        <test property="org.eclipse.acute.isDotnetProject"  
+                           forcePluginActivation="true"/>
+                     </adapt>
+                  </iterate>
+               </with>
+            </enablement>
+         </contextualLaunch>
+      </shortcut>
+   </extension>
 </plugin>

--- a/org.eclipse.acute/src/org/eclipse/acute/ProjectFileAccessor.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/ProjectFileAccessor.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.acute;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.core.runtime.Path;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class ProjectFileAccessor {
+	private static final String[] EMPTY_ARRAY = new String[0];
+
+	public static String[] getTargetFrameworks(Path projectFile) {
+		if (projectFile == null) {
+			return EMPTY_ARRAY;
+		} else if (projectFile.getFileExtension().equals("json")) {
+			try {
+				JSONObject object = new JSONObject(new String(Files.readAllBytes(Paths.get(projectFile.toString()))));
+				Iterator<String> frameworkIterator = object.getJSONObject("frameworks").keys();
+				List<String> frameworks = new ArrayList<>();
+				while (frameworkIterator.hasNext()) {
+					frameworks.add(frameworkIterator.next());
+				}
+				return frameworks.toArray(EMPTY_ARRAY);
+			} catch (JSONException | IOException e) {
+				e.printStackTrace();
+				return EMPTY_ARRAY;
+			}
+
+		} else if (projectFile.getFileExtension().equals("csproj")) {
+			try {
+				DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+				DocumentBuilder builder = factory.newDocumentBuilder();
+				Document doc = builder.parse(projectFile.toFile());
+				doc.getDocumentElement().normalize();
+
+				NodeList nList = doc.getElementsByTagName("PropertyGroup");
+				if (nList.getLength() > 0) {
+					Node propertyGroup = nList.item(0);
+					Node framework = ((Element) propertyGroup).getElementsByTagName("TargetFramework").item(0);
+					if (framework != null) {
+						String allFrameworks = framework.getTextContent();
+						if (!allFrameworks.isEmpty()) {
+							return framework.getTextContent().split(";");
+						}
+					}
+					return EMPTY_ARRAY;
+				}
+				return EMPTY_ARRAY;
+			} catch (ParserConfigurationException | SAXException | IOException e) {
+				return EMPTY_ARRAY;
+			}
+		}
+
+		return EMPTY_ARRAY;
+	}
+}

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnetexport/DotnetExportAccessor.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnetexport/DotnetExportAccessor.java
@@ -13,27 +13,8 @@ package org.eclipse.acute.dotnetexport;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.eclipse.core.runtime.Path;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 public class DotnetExportAccessor {
-	private static final String[] EMPTY_ARRAY = new String[0];
 
 	public static String getDefaultRuntime() {
 		String listCommand = "dotnet --info";
@@ -55,51 +36,5 @@ public class DotnetExportAccessor {
 			return "";
 		}
 		return "";
-	}
-
-	public static String[] getTargetFrameworks(Path projectFile) {
-		if (projectFile == null) {
-			return EMPTY_ARRAY;
-		} else if (projectFile.getFileExtension().equals("json")) {
-			try {
-				JSONObject object = new JSONObject(new String(Files.readAllBytes(Paths.get(
-						projectFile.toString()))));
-				Iterator<String> frameworkIterator = object.getJSONObject("frameworks").keys();
-				List<String> frameworks = new ArrayList<>();
-				while (frameworkIterator.hasNext()) {
-					frameworks.add(frameworkIterator.next());
-				}
-				return frameworks.toArray(EMPTY_ARRAY);
-			} catch (JSONException | IOException e) {
-				e.printStackTrace();
-				return EMPTY_ARRAY;
-			}
-
-		} else if (projectFile.getFileExtension().equals("csproj")) {
-			try {
-				DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder builder = factory.newDocumentBuilder();
-				Document doc = builder.parse(projectFile.toFile());
-				doc.getDocumentElement().normalize();
-
-				NodeList nList = doc.getElementsByTagName("PropertyGroup");
-				if (nList.getLength() > 0) {
-					Node propertyGroup = nList.item(0);
-					Node framework = ((Element) propertyGroup).getElementsByTagName("TargetFramework").item(0);
-					if (framework != null) {
-						String allFrameworks = framework.getTextContent();
-						if (!allFrameworks.isEmpty()) {
-							return framework.getTextContent().split(";");
-						}
-					}
-					return EMPTY_ARRAY;
-				}
-				return EMPTY_ARRAY;
-			} catch (ParserConfigurationException | SAXException | IOException e) {
-				return EMPTY_ARRAY;
-			}
-		}
-
-		return EMPTY_ARRAY;
 	}
 }

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnetexport/DotnetExportWizardPage.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnetexport/DotnetExportWizardPage.java
@@ -15,6 +15,7 @@ import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 import java.io.File;
 import java.net.URL;
 
+import org.eclipse.acute.ProjectFileAccessor;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.fieldassist.ControlDecoration;
@@ -114,7 +115,7 @@ public class DotnetExportWizardPage extends WizardPage {
 		if (projectFile != null) {
 			projectPath = new Path(projectFile.getRawLocation().toString());
 		}
-		targetFrameworks = DotnetExportAccessor.getTargetFrameworks(projectPath);
+		targetFrameworks = ProjectFileAccessor.getTargetFrameworks(projectPath);
 		defaultRuntime = DotnetExportAccessor.getDefaultRuntime();
 	}
 
@@ -284,7 +285,7 @@ public class DotnetExportWizardPage extends WizardPage {
 			frameworkViewer.getList().deselectAll();
 			frameworkViewer.add("Loading frameworks");
 			frameworkViewer.getList().setEnabled(false);
-			targetFrameworks = DotnetExportAccessor.getTargetFrameworks(projectPath);
+			targetFrameworks = ProjectFileAccessor.getTargetFrameworks(projectPath);
 			frameworkViewer.getList().removeAll();
 			if (targetFrameworks.length > 0) {
 				frameworkViewer.add(targetFrameworks);

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestAccessor.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestAccessor.java
@@ -1,0 +1,96 @@
+package org.eclipse.acute.dotnettest;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DotnetTestAccessor {
+
+	/**
+	 * Retrieves and returns a collection of all found tests using the `dotnet test
+	 * --list-tests`command.
+	 *
+	 * @param projectFile:
+	 *            File directed to the .csproj of the interested project
+	 * @return Map<String, List<String>>: Contains the test class as the key and the
+	 *         classe's test methods in list form as the value
+	 */
+	public static Map<String, List<String>> getTestMethods(File projectFile) {
+		Map<String, List<String>> tests = new HashMap<>();
+		if (projectFile == null || !projectFile.exists() || !(projectFile.isFile() || projectFile.isDirectory())) {
+			return tests;
+		}
+
+		if (projectFile.isFile()) {
+			projectFile = projectFile.getParentFile();
+		}
+
+		if (projectFile == null) {
+			return tests;
+		}
+
+		try {
+			ProcessBuilder restorePB;
+			restorePB = new ProcessBuilder("dotnet", "restore");
+			restorePB.directory(projectFile);
+			Process restoreProcess = restorePB.start();
+			restoreProcess.waitFor();
+
+			if (restoreProcess.exitValue() != 0) { // errors will be shown in console
+				return tests;
+			}
+		} catch (InterruptedException | IOException e) {
+			return tests;
+		}
+
+		ProcessBuilder processBuilder;
+		processBuilder = new ProcessBuilder("dotnet", "test", "--list-tests");
+		processBuilder.directory(projectFile);
+
+		try {
+			Process process = processBuilder.start();
+
+			try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+				String inputLine;
+				Boolean testsListExists = false;
+
+				while ((inputLine = in.readLine()) != null) {
+					if (inputLine.equals("The following Tests are available:")) {
+						testsListExists = true;
+						break;
+					}
+				}
+
+				if (testsListExists) {
+					while ((inputLine = in.readLine()) != null) {
+						if (!inputLine.matches("\\s+.*")) {
+							continue;
+						}
+						String FullyQualifiedName = inputLine.replaceFirst("\\s+", "").replaceAll("\\(.*\\)", "");
+						int index = FullyQualifiedName.lastIndexOf('.');
+						String className = FullyQualifiedName.substring(0, index);
+						String methodName = FullyQualifiedName.substring(index + 1, FullyQualifiedName.length());
+						List<String> methods = tests.get(className);
+						if(methods == null) {
+							methods = new ArrayList<>();
+						} else if (methods.contains(methodName)) {
+							continue;
+						}
+						methods.add(methodName);
+						tests.put(className, methods);
+					}
+				}
+				return tests;
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+			return tests;
+		}
+	}
+}

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestDelegate.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestDelegate.java
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.acute.dotnettest;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.Launch;
+import org.eclipse.debug.core.model.LaunchConfigurationDelegate;
+import org.eclipse.debug.ui.ILaunchShortcut;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+
+public class DotnetTestDelegate extends LaunchConfigurationDelegate implements ILaunchShortcut {
+
+	public static String ALL_TESTS = "ALL";
+	public static String MATCHING_TESTS = "MATCHING";
+	public static String SELECTED_TEST = "SELECTED";
+
+	@Override
+	public void launch(ISelection selection, String mode) {
+
+		if (selection instanceof IStructuredSelection) {
+			Iterator<Object> selectionIterator = ((IStructuredSelection) selection).iterator();
+			while (selectionIterator.hasNext()) {
+				Object element = selectionIterator.next();
+				IResource resource = null;
+				if (element instanceof IResource) {
+					resource = (IResource) element;
+				} else if (element instanceof IAdaptable) {
+					resource = ((IAdaptable) element).getAdapter(IResource.class);
+				}
+
+				if (resource != null) {
+					try {
+						ILaunchConfiguration launchConfig = getLaunchConfiguration(mode, resource);
+						launchConfig.launch(mode, new NullProgressMonitor());
+					} catch (CoreException e) {
+						e.printStackTrace();
+					}
+					return;
+				}
+			}
+		}
+		Display.getDefault().asyncExec(() -> {
+			MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					"Unable to run test", "Unable to run .NET Core tests from selection.");
+		});
+	}
+
+	@Override
+	public void launch(IEditorPart editor, String mode) {
+		IEditorInput input = editor.getEditorInput();
+		IFile file = input.getAdapter(IFile.class);
+
+		try {
+			ILaunchConfiguration launchConfig = getLaunchConfiguration(mode, file);
+			launchConfig.launch(mode, new NullProgressMonitor());
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
+			throws CoreException {
+		String projectLocation = configuration.getAttribute("PROJECT_PATH", "");
+		String projectConfiguration = configuration.getAttribute("CONFIGURATION", "Debug");
+		String projectFramework = configuration.getAttribute("FRAMEWORK", "");
+		String testSelectionMethod = configuration.getAttribute("TEST_SELECTION_TYPE", ALL_TESTS);
+		String selectionFilter = configuration.getAttribute("TEST_FILTER", "");
+		String selectionClass = configuration.getAttribute("TEST_CLASS", "");
+		String selectionMethod = configuration.getAttribute("TEST_METHOD", "");
+		boolean buildProject = configuration.getAttribute("PROJECT_BUILD", true);
+		boolean restoreProject = configuration.getAttribute("PROJECT_RESTORE", true);
+
+		File projectFile = new File(projectLocation);
+
+		if (projectFile != null && projectFile.isFile()) {
+			projectFile = projectFile.getParentFile();
+		}
+
+		if (!projectFile.exists() || projectFile == null) {
+			MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					"Unable to run test", "Unable to run .NET Core tests from specified location.");
+			return;
+
+		}
+
+		List<String> commandList = new ArrayList<>();
+		commandList.add("dotnet");
+		commandList.add("test");
+
+		if (!projectConfiguration.isEmpty()) {
+			commandList.add("-c");
+			commandList.add(projectConfiguration);
+		}
+
+		if (!projectFramework.isEmpty()) {
+			commandList.add("-f");
+			commandList.add(projectFramework);
+		}
+
+		if (testSelectionMethod.equals(MATCHING_TESTS) && !selectionFilter.isEmpty()) {
+			commandList.add("--filter");
+			commandList.add(selectionFilter);
+		} else if (testSelectionMethod.equals(SELECTED_TEST) && !selectionClass.isEmpty()) {
+			commandList.add("--filter");
+			if (selectionMethod.isEmpty()) {
+				commandList.add("FullyQualifiedName~" + selectionClass);
+			} else {
+				commandList.add("FullyQualifiedName=" + selectionClass + "." + selectionMethod);
+
+			}
+		}
+
+		if (!buildProject) {
+			commandList.add("--no-build");
+		}
+
+		if (restoreProject) {
+			ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+			ILaunch newLaunch = new Launch(null, ILaunchManager.RUN_MODE, null);
+
+			Process restoreProcess = DebugPlugin.exec(new String[] { "dotnet", "restore" }, projectFile);
+			DebugPlugin.newProcess(launch, restoreProcess, ".NET Core Restore");
+			launchManager.addLaunch(newLaunch);
+
+			try {
+				restoreProcess.waitFor();
+			} catch (InterruptedException e) {
+			}
+			if (restoreProcess.exitValue() != 0) { // errors will be shown in console
+				return;
+			}
+		}
+
+		Process p = DebugPlugin.exec(commandList.toArray(new String[commandList.size()]), projectFile);
+		DebugPlugin.newProcess(launch, p, ".NET Core Tests");
+	}
+
+	private ILaunchConfiguration getLaunchConfiguration(String mode, IResource resource) {
+		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+		ILaunchConfigurationType configType = launchManager
+				.getLaunchConfigurationType("org.eclipse.acute.dotnettest.DotnetTestDelegate");
+		try {
+			ILaunchConfiguration[] launchConfigurations = launchManager.getLaunchConfigurations(configType);
+
+			String configName;
+			if (resource.getLocation().toFile().isFile()) {
+				configName = resource.getParent().getName() + "." + resource.getName() + " Configuration";
+			} else {
+				configName = resource.getName() + " Configuration";
+			}
+
+			for (ILaunchConfiguration iLaunchConfiguration : launchConfigurations) {
+				if (iLaunchConfiguration.getName().equals(configName)
+						&& iLaunchConfiguration.getModes().contains(mode)) {
+					return iLaunchConfiguration;
+				}
+			}
+			configName = launchManager.generateLaunchConfigurationName(configName);
+			ILaunchConfigurationWorkingCopy wc = configType.newInstance(null, configName);
+			if (resource.getLocation().toFile().isFile()) {
+				if (resource.getFileExtension().equals("cs")) {
+					wc.setAttribute("TEST_SELECTION_TYPE", SELECTED_TEST);
+					wc.setAttribute("TEST_CLASS", resource.getName().replaceFirst("\\.cs$", ""));
+				}
+				resource = resource.getParent();
+			}
+			wc.setAttribute("PROJECT_PATH", resource.getLocation().toString());
+
+			return wc;
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestTab.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestTab.java
@@ -1,0 +1,504 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.acute.dotnettest;
+
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.acute.ProjectFileAccessor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.ListViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.RowLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+
+public class DotnetTestTab extends AbstractLaunchConfigurationTab {
+	private String projectConfig;
+	private Path projectPath;
+	private String testType;
+
+	// Map<ClassName, List<MethodName>>
+	private Map<String, List<String>> testMethods;
+	private String[] targetFrameworks;
+	private String loadedSelectedTargetFramework;
+	private String loadedTestsParentProject;
+
+	private Text pathText;
+	private Button runAllRadio;
+	private Button runMatchingRadio;
+	private Label filterLabel;
+	private Text filterText;
+	private Button runSelectedRadio;
+	private Label classLabel;
+	private Text classText;
+	private Button classBrowseButton;
+	private Label methodLabel;
+	private Text methodText;
+	private Button methodBrowseButton;
+	private ListViewer frameworkViewer;
+	private Button releaseRadio;
+	private Button debugRadio;
+	private Button buildCheckBoxButton;
+	private Button restoreCheckBoxButton;
+
+	@Override
+	public void createControl(Composite parent) {
+		Composite container = new Group(parent, SWT.BORDER);
+		setControl(container);
+		GridLayoutFactory.swtDefaults().numColumns(4).applyTo(container);
+
+		Label pathLabel = new Label(container, SWT.NONE);
+		pathLabel.setText("Project:");
+		pathLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+
+		pathText = new Text(container, SWT.BORDER);
+		pathText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		pathText.addModifyListener(e -> {
+			updateProjectPath(pathText.getText());
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		});
+
+		Button browseButton = new Button(container, SWT.NONE);
+		browseButton.setText("Browse...");
+		browseButton.addSelectionListener(widgetSelectedAdapter(e -> {
+			FileDialog dialog = new FileDialog(browseButton.getShell());
+			String path = dialog.open();
+			if (path != null) {
+				pathText.setText(path);
+				updateProjectPath(path.toString());
+				setDirty(true);
+				updateLaunchConfigurationDialog();
+			}
+		}));
+
+		runAllRadio = new Button(container, SWT.RADIO);
+		runAllRadio.setText("Run all tests");
+		runAllRadio.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1));
+		runAllRadio.addSelectionListener(widgetSelectedAdapter(e -> {
+			switchSelector(DotnetTestDelegate.ALL_TESTS);
+		}));
+
+		runMatchingRadio = new Button(container, SWT.RADIO);
+		runMatchingRadio.setText("Run tests matching the following filter");
+		runMatchingRadio.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1));
+		runMatchingRadio.addSelectionListener(widgetSelectedAdapter(e -> {
+			switchSelector(DotnetTestDelegate.MATCHING_TESTS);
+		}));
+
+		filterLabel = new Label(container, SWT.NONE);
+		filterLabel.setText("Test Filter:");
+		filterLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+
+		filterText = new Text(container, SWT.BORDER);
+		filterText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		filterText.addModifyListener(e -> {
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		});
+		new Label(container, SWT.NONE);
+
+		runSelectedRadio = new Button(container, SWT.RADIO);
+		runSelectedRadio.setText("Run a single test");
+		runSelectedRadio.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 4, 1));
+		runSelectedRadio.addSelectionListener(widgetSelectedAdapter(e -> {
+			switchSelector(DotnetTestDelegate.SELECTED_TEST);
+		}));
+
+		classLabel = new Label(container, SWT.NONE);
+		classLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		classLabel.setText("Test class:");
+
+		classText = new Text(container, SWT.BORDER);
+		classText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		classText.addModifyListener(e -> {
+			if (classText.getText().isEmpty()) {
+				methodBrowseButton.setEnabled(true);
+				methodLabel.setEnabled(true);
+				methodText.setEnabled(true);
+			}
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		});
+
+		classBrowseButton = new Button(container, SWT.NONE);
+		classBrowseButton.setText("Search");
+		classBrowseButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		classBrowseButton.addSelectionListener(widgetSelectedAdapter(e -> {
+			searchForTestClass();
+		}));
+
+		methodLabel = new Label(container, SWT.NONE);
+		methodLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		methodLabel.setText("Test method:");
+
+		methodText = new Text(container, SWT.BORDER);
+		methodText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		methodText.setMessage("(all methods)");
+		methodText.addModifyListener(e -> {
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		});
+
+		methodBrowseButton = new Button(container, SWT.NONE);
+		methodBrowseButton.setText("Search");
+		methodBrowseButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		methodBrowseButton.addSelectionListener(widgetSelectedAdapter(e -> {
+			searchForTestMethods();
+		}));
+
+		Label configLabel = new Label(container, SWT.NONE);
+		configLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		configLabel.setText("Configuration:");
+
+		Composite configComp = new Composite(container, SWT.NULL);
+		configComp.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 3, 1));
+		configComp.setLayout(new RowLayout());
+
+		Listener configRadioListener = new Listener() {
+			@Override
+			public void handleEvent(Event e) {
+				projectConfig = ((Button) e.widget).getText();
+				setDirty(true);
+				updateLaunchConfigurationDialog();
+			}
+		};
+
+		debugRadio = new Button(configComp, SWT.RADIO);
+		debugRadio.setText("Debug");
+		debugRadio.addListener(SWT.Selection, configRadioListener);
+
+		releaseRadio = new Button(configComp, SWT.RADIO);
+		releaseRadio.setText("Release");
+		releaseRadio.addListener(SWT.Selection, configRadioListener);
+
+		Label frameworkLabel = new Label(container, SWT.NONE);
+		frameworkLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		frameworkLabel.setText("Framework:");
+
+		org.eclipse.swt.widgets.List list = new org.eclipse.swt.widgets.List(container, SWT.V_SCROLL | SWT.BORDER);
+		GridData listBoxData = new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1);
+		listBoxData.heightHint = 50;
+		list.setLayoutData(listBoxData);
+
+		new Label(container, SWT.NONE).setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 4, 1));
+
+		buildCheckBoxButton = new Button(container, SWT.CHECK);
+		buildCheckBoxButton.setSelection(true);
+		buildCheckBoxButton.setText("Build project");
+		buildCheckBoxButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 4, 1));
+		buildCheckBoxButton.addSelectionListener(widgetSelectedAdapter(e -> {
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		}));
+
+		restoreCheckBoxButton = new Button(container, SWT.CHECK);
+		restoreCheckBoxButton.setSelection(true);
+		restoreCheckBoxButton.setText("Restore project");
+		restoreCheckBoxButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 4, 1));
+		restoreCheckBoxButton.addSelectionListener(widgetSelectedAdapter(e -> {
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		}));
+
+		list.setEnabled(false);
+		frameworkViewer = new ListViewer(list);
+		frameworkViewer.setContentProvider(new ArrayContentProvider());
+		frameworkViewer.add("No frameworks available");
+	}
+
+	@Override
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+		configuration.setAttribute("PROJECT_PATH", "");
+		configuration.setAttribute("TEST_SELECTION_TYPE", DotnetTestDelegate.ALL_TESTS);
+		configuration.setAttribute("TEST_FILTER", "");
+		configuration.setAttribute("TEST_CLASS", "");
+		configuration.setAttribute("TEST_METHOD", "");
+		configuration.setAttribute("CONFIGURATION", "Debug");
+		configuration.setAttribute("FRAMEWORK", "");
+		configuration.setAttribute("PROJECT_BUILD", true);
+		configuration.setAttribute("PROJECT_RESTORE", true);
+	}
+
+	@Override
+	public void initializeFrom(ILaunchConfiguration configuration) {
+		try {
+			pathText.setText(configuration.getAttribute("PROJECT_PATH", ""));
+		} catch (CoreException ce) {
+			pathText.setText("");
+		}
+		try {
+			filterText.setText(configuration.getAttribute("TEST_FILTER", ""));
+		} catch (CoreException ce) {
+			filterText.setText("");
+		}
+		try {
+			classText.setText(configuration.getAttribute("TEST_CLASS", ""));
+		} catch (CoreException ce) {
+			classText.setText("");
+		}
+		try {
+			methodText.setText(configuration.getAttribute("TEST_METHOD", ""));
+		} catch (CoreException ce) {
+			methodText.setText("");
+		}
+
+		try {
+			testType = configuration.getAttribute("TEST_SELECTION_TYPE", DotnetTestDelegate.ALL_TESTS);
+		} catch (CoreException ce) {
+			testType = DotnetTestDelegate.ALL_TESTS;
+		} finally {
+			switchSelector(testType);
+			runSelectedRadio.setSelection(false);
+			runMatchingRadio.setSelection(false);
+			runAllRadio.setSelection(false);
+			if (testType.equals(DotnetTestDelegate.SELECTED_TEST)) {
+				runSelectedRadio.setSelection(true);
+			} else if (testType.equals(DotnetTestDelegate.MATCHING_TESTS)) {
+				runMatchingRadio.setSelection(true);
+			} else {
+				runAllRadio.setSelection(true);
+			}
+		}
+
+		try {
+			projectConfig = configuration.getAttribute("CONFIGURATION", "Debug");
+		} catch (CoreException ce) {
+			projectConfig = "Debug";
+		} finally {
+			if (projectConfig.equals("Debug")) {
+				debugRadio.setSelection(true);
+				releaseRadio.setSelection(false);
+			} else {
+				releaseRadio.setSelection(true);
+				debugRadio.setSelection(false);
+			}
+		}
+		try {
+			loadedSelectedTargetFramework = configuration.getAttribute("FRAMEWORK", "");
+		} catch (CoreException ce) {
+			// no selection to load
+		}
+		try {
+			buildCheckBoxButton.setSelection(configuration.getAttribute("PROJECT_BUILD", true));
+		} catch (CoreException ce) {
+			buildCheckBoxButton.setSelection(true);
+		}
+		try {
+			restoreCheckBoxButton.setSelection(configuration.getAttribute("PROJECT_RESTORE", true));
+		} catch (CoreException ce) {
+			restoreCheckBoxButton.setSelection(true);
+		}
+	}
+
+	@Override
+	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+		configuration.setAttribute("PROJECT_PATH", pathText.getText());
+		configuration.setAttribute("TEST_SELECTION_TYPE", testType);
+		configuration.setAttribute("TEST_FILTER", filterText.getText());
+		configuration.setAttribute("TEST_CLASS", classText.getText());
+		configuration.setAttribute("TEST_METHOD", methodText.getText());
+		configuration.setAttribute("CONFIGURATION", projectConfig);
+		configuration.setAttribute("FRAMEWORK", getTargetFramework());
+		configuration.setAttribute("PROJECT_BUILD", buildCheckBoxButton.getSelection());
+		configuration.setAttribute("PROJECT_RESTORE", restoreCheckBoxButton.getSelection());
+
+		setDirty(false);
+	}
+
+	@Override
+	public String getName() {
+		return "Main";
+	}
+
+	private void switchSelector(String type) {
+
+		filterLabel.setEnabled(false);
+		filterText.setEnabled(false);
+		classBrowseButton.setEnabled(false);
+		classLabel.setEnabled(false);
+		classText.setEnabled(false);
+		methodBrowseButton.setEnabled(false);
+		methodLabel.setEnabled(false);
+		methodText.setEnabled(false);
+
+		if (type.equals(DotnetTestDelegate.SELECTED_TEST)) {
+			classBrowseButton.setEnabled(true);
+			classLabel.setEnabled(true);
+			classText.setEnabled(true);
+			if (!classText.getText().isEmpty()) {
+				methodBrowseButton.setEnabled(true);
+				methodLabel.setEnabled(true);
+				methodText.setEnabled(true);
+			}
+			testType = DotnetTestDelegate.SELECTED_TEST;
+		} else if (type.equals(DotnetTestDelegate.MATCHING_TESTS)) {
+			filterLabel.setEnabled(true);
+			filterText.setEnabled(true);
+			testType = DotnetTestDelegate.MATCHING_TESTS;
+		} else {
+			testType = DotnetTestDelegate.ALL_TESTS;
+		}
+
+		setDirty(true);
+		updateLaunchConfigurationDialog();
+	}
+
+	private void updateProjectPath(String location) {
+		projectPath = new Path(location);
+		updateFrameworkList();
+	}
+
+	private void searchForTestClass() {
+		if (!pathText.getText().equals(loadedTestsParentProject) || testMethods == null) {
+			loadedTestsParentProject = pathText.getText();
+			testMethods = null;
+			Job.create("Retrive Test Classes", (ICoreRunnable) monitor -> {
+				testMethods = DotnetTestAccessor.getTestMethods(projectPath.toFile());
+				Display.getDefault().asyncExec(() -> {
+					displayClassSelectorDialog();
+				});
+			}).schedule();
+		} else {
+			displayClassSelectorDialog();
+		}
+	}
+
+	private void displayClassSelectorDialog() {
+
+		ElementListSelectionDialog dialog = new ElementListSelectionDialog(classBrowseButton.getShell(),
+				new LabelProvider());
+		dialog.setTitle("Class Selection");
+		dialog.setMessage("Select a class (* = any string, ? = any char):");
+		dialog.setElements(testMethods.keySet().toArray());
+		dialog.open();
+		String selected = (String) dialog.getFirstResult();
+		if (selected != null) {
+			methodBrowseButton.setEnabled(true);
+			methodLabel.setEnabled(true);
+			methodText.setEnabled(true);
+			classText.setText(selected);
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		}
+	}
+
+	private void searchForTestMethods() {
+		if (!pathText.getText().equals(loadedTestsParentProject) || testMethods == null) {
+			loadedTestsParentProject = pathText.getText();
+			testMethods = null;
+			Job.create("Retrive Test Classes", (ICoreRunnable) monitor -> {
+				testMethods = DotnetTestAccessor.getTestMethods(projectPath.toFile());
+				Display.getDefault().asyncExec(() -> {
+					displayMethodSelectorDialog();
+				});
+			}).schedule();
+		} else {
+			displayMethodSelectorDialog();
+		}
+	}
+
+	private void displayMethodSelectorDialog() {
+		ElementListSelectionDialog dialog = new ElementListSelectionDialog(classBrowseButton.getShell(),
+				new LabelProvider());
+		dialog.setTitle("Method Selection from \"" + classText.getText() + "\"");
+		dialog.setMessage("Select a method (* = any string, ? = any char):");
+		List<String> methods = testMethods.get(classText.getText());
+		if(methods!=null) {
+			dialog.setElements(methods.toArray());
+		}
+		dialog.open();
+		String selected = (String) dialog.getFirstResult();
+		if (selected != null) {
+			methodText.setText(selected);
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		}
+	}
+
+	private void updateFrameworkList() {
+		frameworkViewer.getList().removeAll();
+		if (isProjectFile(projectPath)) {
+			frameworkViewer.getList().deselectAll();
+			frameworkViewer.add("Loading frameworks");
+			frameworkViewer.getList().setEnabled(false);
+			targetFrameworks = ProjectFileAccessor.getTargetFrameworks(projectPath);
+			frameworkViewer.getList().removeAll();
+
+			if (targetFrameworks.length > 0) {
+				frameworkViewer.add(targetFrameworks);
+				frameworkViewer.getList().select(0);
+				frameworkViewer.getList().setEnabled(true);
+				loadFramework();
+				return;
+			}
+		}
+
+		frameworkViewer.add("No frameworks available");
+	}
+
+	private void loadFramework() {
+		if (loadedSelectedTargetFramework == null || loadedSelectedTargetFramework.isEmpty()) {
+			return;
+		}
+		int index = 0;
+		for (String framework : frameworkViewer.getList().getItems()) {
+			if (framework.equals(loadedSelectedTargetFramework)) {
+				frameworkViewer.getList().select(index);
+				break;
+			}
+			index++;
+		}
+		loadedSelectedTargetFramework = null;
+	}
+
+	private boolean isProjectFile(Path path) {
+		if (path == null || path.isEmpty()) {
+			return false;
+		} else if (!path.lastSegment().matches("(.*\\.csproj|project.json)")) {
+			return false;
+		} else if (!path.toFile().isFile()) {
+			return false;
+		}
+		return true;
+	}
+
+	public String getTargetFramework() {
+		IStructuredSelection selection = (IStructuredSelection) frameworkViewer.getSelection();
+		if (selection.isEmpty()) {
+			return "";
+		}
+		return (String) selection.getFirstElement();
+	}
+
+}

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestTabGroup.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnettest/DotnetTestTabGroup.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.acute.dotnettest;
+
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
+import org.eclipse.debug.ui.CommonTab;
+import org.eclipse.debug.ui.ILaunchConfigurationDialog;
+import org.eclipse.debug.ui.ILaunchConfigurationTab;
+
+public class DotnetTestTabGroup extends AbstractLaunchConfigurationTabGroup {
+
+	@Override
+	public void createTabs(ILaunchConfigurationDialog arg0, String arg1) {
+		setTabs(new ILaunchConfigurationTab[] { new DotnetTestTab(), new CommonTab() });
+	}
+
+}

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -1,37 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="aCute" sequenceNumber="4">
+<?pde version="3.8"?><target name="aCute" sequenceNumber="5">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.lsp4e" version="0.0.0"/>
 <repository location="http://download.eclipse.org/lsp4e/snapshots/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="tm-feature.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/tm4e/snapshots/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<!-- Include for joni and jcodings -->
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="0.0.0"/>
 <repository location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
 <unit id="org.eclipse.platform.ide" version="0.0.0"/>
 <unit id="org.eclipse.ui.genericeditor" version="0.0.0"/>
-<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
-<unit id="org.junit" version="0.0.0"/>
 <unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.7/"/>
+<unit id="org.junit" version="0.0.0"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <repository location="http://download.eclipse.org/releases/oxygen/"/>
 </location>
-<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/cbi/updates/license/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.eclipse.feature.group"  version="0.0.0"/>
-<unit id="org.eclipse.swtbot.feature.group"  version="0.0.0"/>
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
- Test configuration creates .launch file
- Loads tests from `dotnet test --list-test` command
- Able to load config tab from .launch file
- Tests run from config or shortcuts
- Test suite:
	- Confirm able to run successful and not tests
	- able to select specific test for config